### PR TITLE
Pass createConnection callback through untouched

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,11 +14,8 @@ adapter.createQuery = function (text, params, callback) {
 
 adapter.createConnection = function (opts, callback) {
   var conn = new PostgresConnection(opts)
-  conn.connect(function (err) {
-    if (err) return callback ? callback(err) : conn.emit('error', err)
-    conn.emit('open')
-    if (callback) callback(null, conn)
-  })
+  conn.connect(callback)
+  conn.once('connect', conn.emit.bind(conn, 'open'))
   return conn
 }
 


### PR DESCRIPTION
This prevents `pg.js` from acting like the user supplied a callback in cases where they didn't

This should fix the issue @kamholz discovered over on #5 
