### PR TITLE
allow query end without callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,8 @@ function PostgresQuery (text, params, callback) {
       .on('end', function () {
         if (!errored) this.callback(null, this._result)
       })
+  } else {
+    setImmediate(this.read.bind(this))
   }
 }
 


### PR DESCRIPTION
On a readable stream, if `read` or `on('data')` aren't used then the
stream will not emit the `end` event.
Why? I can't really understand, but maybe you can:
https://github.com/joyent/node/commit/327b6e3e1de88ba1db83142d53b3a57f0d06d519

When a PostgresQuery is created without a callback, `on('data')` isn't
set, so `'end'` never fires, and when using a connection pool, the
connection will not be released.

The solution, as ugly as it may be, is to "kickstart" the readable
stream by calling `.read()`. Consider it a tribute to the Node stream
spectacle.
